### PR TITLE
Initial SDK repo template

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,20 @@
+# http://editorconfig.org
+
+# ---------------------------------------------------------------------
+# DO NOT CHANGE THIS SECTION
+
+root = true
+
+[*]
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+charset = utf-8
+indent_style = space
+indent_size = 2
+
+[*.md]
+trim_trailing_whitespace = false
+
+# ---------------------------------------------------------------------
+# Add specific rules here… (Note: What you add can have an effect on Prettier)

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,11 @@
+# https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
+
+# ---------------------------------------------------------------------
+# DO NOT CHANGE THIS SECTION
+
+# These owners will be the default owners for everything in the repo. Unless a
+# later match takes precedence.
+* @daveordead @rairaman
+
+# ---------------------------------------------------------------------
+# Add specific owners here…

--- a/.gitignore
+++ b/.gitignore
@@ -1,18 +1,25 @@
-# Build and Release Folders
-bin-debug/
-bin-release/
-[Oo]bj/
-[Bb]in/
+# https://git-scm.com/docs/gitignore
 
-# Other files and folders
-.settings/
+# ---------------------------------------------------------------------
+# DO NOT CHANGE THIS SECTION
 
-# Executables
-*.swf
-*.air
-*.ipa
-*.apk
+# Dependencies
+node_modules/
 
-# Project files, i.e. `.project`, `.actionScriptProperties` and `.flexProperties`
-# should NOT be excluded as they contain compiler settings and other important
-# information for Eclipse / Flash Builder.
+# Compiled output
+dist/
+build/
+coverage/
+
+# Generated at runtime
+*.log
+.cache
+
+# Personal files
+.idea
+
+# System files
+.DS_Store
+
+# ---------------------------------------------------------------------
+# Add specific rules here…

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,3 @@
+dist/
+build/
+coverage/

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,7 @@
+{
+  "singleQuote": true,
+  "trailingComma": "none",
+  "bracketSpacing": false,
+  "proseWrap": "never",
+  "overrides": []
+}

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,7 @@
+{
+  "recommendations": [
+    "yzhang.markdown-all-in-one",
+    "editorconfig.editorconfig",
+    "esbenp.prettier-vscode"
+  ]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,13 @@
+{
+  "editor.defaultFormatter": "esbenp.prettier-vscode",
+  "editor.codeActionsOnSave": {"source.fixAll": true},
+  "editor.formatOnSave": true,
+  "files.trimTrailingWhitespace": true,
+  "markdown.extension.italic.indicator": "_",
+  "markdown.extension.toc.unorderedList.marker": "-",
+  "markdown.extension.toc.slugifyMode": "github",
+  "markdown.preview.fontFamily": "system-ui, -apple-system, sans-serif",
+  "files.associations": {
+    "CODEOWNERS": "ini"
+  }
+}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,1 @@
+<!-- Ideally, this should get auto-generated via tools like [auto-changelog](https://github.com/CookPete/auto-changelog). Eventually, this will get set up as part of the repository template. -->

--- a/README.md
+++ b/README.md
@@ -1,2 +1,42 @@
-# repo-template
-A template for all new kinde-oss repositories
+# 👉 To complete this README and ensure it follows the README template, please action the following: 👈
+
+- 👀 [See here](https://github.com/kinde-oss/.github/blob/02d19d8d2225444a29d2d2046a2726f7b17155fb/.github/CONTRIBUTING.md#sdks) to learn about the generator and non-generator repositories.
+- 🧹 Once complete, remove this entire section.
+
+## For both types of repositories (generator and non-generator)
+
+- [ ] Replace all instances of `[technology/framework name]` placeholder with the technology or framework for this SDK, e.g. “Kinde React” or “Kinde Elixir”. For generator repositories, add “generator” at the end, e.g. “Kinde React generator” or “Kinde Elixir generator”.
+
+## For generator repositories
+
+- [ ] Remove the “Documentation” section and replace it with relevant sections this README requires.
+- [ ] Remove the “Publishing” section.
+
+## For non-generator repositories
+
+- [ ] Refrain from adding information to this README that should be in the corresponding Kinde document (linked from the “Documentation” section below). If information is missing from the Kinde document, please submit an [issue](https://github.com/kinde-oss/.github/blob/02d19d8d2225444a29d2d2046a2726f7b17155fb/.github/CONTRIBUTING.md#issues) via the “Documentation issue” template or start a chat in the Kinde community via the [#documentation channel](https://thekindecommunity.slack.com/archives/C057M2BQ6LV). **This README should follow the structure in this template.** If custom information is required that, for some reason, does not belong in the Kinde document, add it **above** the “Documentation” section.
+- [ ] If possible, add the [“Version”](https://shields.io/category/version) and [“Build”](https://shields.io/category/build) shields as the first shields in the list.
+- [ ] Add the corresponding Kinde SDK document URL to the link in the “Documentation” section. All Kinde documents are [here](https://kinde.com/docs/developer-tools).
+- [ ] Add documentation to the “Publishing” section covering how this repository’s package gets published.
+
+# Kinde [technology/framework name]
+
+The Kinde SDK for [technology/framework name].
+
+[![PRs Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg?style=flat-square)](https://makeapullrequest.com) [![Kinde Docs](https://img.shields.io/badge/Kinde-Docs-eee?style=flat-square)](https://kinde.com/docs/developer-tools) [![Kinde Community](https://img.shields.io/badge/Kinde-Community-eee?style=flat-square)](https://thekindecommunity.slack.com)
+
+## Documentation
+
+Please refer to the Kinde [[technology/framework name] SDK document]().
+
+## Publishing
+
+[Details here]
+
+## Contributing
+
+Please refer to Kinde’s [contributing guidelines](https://github.com/kinde-oss/.github/blob/489e2ca9c3307c2b2e098a885e22f2239116394a/CONTRIBUTING.md).
+
+## License
+
+By contributing to Kinde, you agree that your contributions will be licensed under its MIT License.

--- a/_NEW_REPO_CHECKLIST_.md
+++ b/_NEW_REPO_CHECKLIST_.md
@@ -1,0 +1,15 @@
+Once you've created a new repository, please complete the following checklist:
+
+- [ ] Complete the README (see instructions at the top of the file).
+- [ ] If needed for this repository’s technology or framework, add rules or overrides (to the marked section if present) to the following configuration files:
+  - [ ] `.editorconfig`
+  - [ ] `.prettierrc` (only add to the `overrides` array)
+  - [ ] `.prettierignore`
+  - [ ] `.gitignore`
+  - [ ] `.vscode/*.json`
+  - [ ] `.github/CODEOWNERS`
+- [ ] Add a linting configuration to this repository. E.g. if JavaScript-based, add [ESLint](https://eslint.org/docs/latest/use/getting-started). _Ideally, a lint task should run automatically on every commit to avoid being human linters in pull requests (see [lint-staged](https://github.com/okonet/lint-staged))._
+- [ ] Add the relevant package configuration file. E.g. if an npm package, add a [package.json](https://docs.npmjs.com/cli/v9/configuring-npm/package-json) file.
+- [ ] Add the relevant publishing pipeline and document it in the README (see instructions there). E.g. a [GitHub Action](https://github.com/features/actions) pipeline.
+- [ ] Refrain from adding [community health files](https://docs.github.com/en/communities/setting-up-your-project-for-healthy-contributions/creating-a-default-community-health-file) to the `.github` folder (see the contributing guidelines [here](https://github.com/kinde-oss/.github/blob/02d19d8d2225444a29d2d2046a2726f7b17155fb/.github/CONTRIBUTING.md#community-health-files)).
+- [ ] Once the checklist is complete, delete this file.


### PR DESCRIPTION
# Explain your changes

This is the SDK repo template, which we should use when creating a new SDK repository.

I've included a checklist (`_NEW_REPO_CHECKLIST_.md`) that should get looked at once a new repo is created. I've also added a "New repositories" section to the contributing doc (see https://github.com/kinde-oss/.github/pull/6).

We can add more to this template over time or even do specific templates for different technologies and package managers, e.g., JavaScript/npm. For now, these tasks are in the `_NEW_REPO_CHECKLIST_.md` checklist, e.g.:

- [ ] Add a linting configuration to this repository. E.g. if JavaScript-based, add [ESLint](https://eslint.org/docs/latest/use/getting-started). _Ideally, a lint task should run automatically on every commit to avoid being human linters in pull requests (see [lint-staged](https://github.com/okonet/lint-staged))._
- [ ] Add the relevant package configuration file. E.g. if an npm package, add a [package.json](https://docs.npmjs.com/cli/v9/configuring-npm/package-json) file.
- [ ] Add the relevant publishing pipeline and document it in the README (see instructions there). E.g. a [GitHub Action](https://github.com/features/actions) pipeline.

There is also the task to set up changelogs universally.

**Note:** I've captured these further tasks in Notion [here](https://www.notion.so/kinde/caccbfc688484e989efa91981461cdac?v=c420b9ba55dd44f3bd28c1d08564899a).

# Checklist

- [x] I have read the [“Pull requests” section](https://github.com/kinde-oss/.github/blob/489e2ca9c3307c2b2e098a885e22f2239116394a/CONTRIBUTING.md#pull-requests) in the [contributing guidelines](https://github.com/kinde-oss/.github/blob/489e2ca9c3307c2b2e098a885e22f2239116394a/CONTRIBUTING.md).
- [x] I agree to the terms within the [code of conduct](https://github.com/kinde-oss/.github/blob/489e2ca9c3307c2b2e098a885e22f2239116394a/CODE_OF_CONDUCT.md).

🛟 _If you need help, consider asking for advice over in the [Kinde community](https://thekindecommunity.slack.com)._
